### PR TITLE
Add Python 3.x support

### DIFF
--- a/binali.py
+++ b/binali.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
 import random

--- a/binali.py
+++ b/binali.py
@@ -11,6 +11,6 @@ parser.add_argument('--feda', action='store_const', const=29)
 args = parser.parse_args()
 
 if args.feda is not None:
-	print binaliQuotes[args.feda]
+	print(binaliQuotes[args.feda])
 else:
-	print random.choice(binaliQuotes)
+	print(random.choice(binaliQuotes))


### PR DESCRIPTION
- Python 3 uyumluluğu için print ifadesi yerine print() fonksiyonunu kullandım.
- Sabit bir çalıştırılabilir dosya konumu (`/usr/bin/python`) yerine ortam değişkenleri içerisindeki konumu kullandım. Böylece farklı konumlarda farklı python sürümleri kullanılan ortamlarda sorunsuz çalışabilecek.